### PR TITLE
Hide NotFound struct member from Mux, and expose as an interface.

### DIFF
--- a/matcher.go
+++ b/matcher.go
@@ -106,7 +106,7 @@ func (a *andMatcher) match(req *http.Request) *match {
 
 // Regular expression matcher, takes a regular expression and requestMapper
 type regexpMatcher struct {
-	// Uses this mapper to extract a string from a request to match agains
+	// Uses this mapper to extract a string from a request to match against
 	mapper requestMapper
 	// Compiled regular expression
 	expr *regexp.Regexp

--- a/mux.go
+++ b/mux.go
@@ -56,6 +56,10 @@ func (m *Mux) GetNotFound() http.Handler {
 	return m.notFound
 }
 
+func (m *Mux) IsValid(expr string) bool {
+	return IsValid(expr)
+}
+
 // NotFound is a generic http.Handler for request
 type notFound struct {
 }
@@ -67,3 +71,4 @@ func (notFound) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, "Not found")
 
 }
+

--- a/mux.go
+++ b/mux.go
@@ -8,7 +8,7 @@ import (
 // Mux implements router compatible with http.Handler
 type Mux struct {
 	// NotFound sets handler for routes that are not found
-	NotFound http.Handler
+	notFound http.Handler
 	router   Router
 }
 
@@ -16,7 +16,7 @@ type Mux struct {
 func NewMux() *Mux {
 	return &Mux{
 		router:   New(),
-		NotFound: &NotFound{},
+		notFound: &notFound{},
 	}
 }
 
@@ -38,18 +38,30 @@ func (m *Mux) Remove(expr string) error {
 func (m *Mux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h, err := m.router.Route(r)
 	if err != nil || h == nil {
-		m.NotFound.ServeHTTP(w, r)
+		m.notFound.ServeHTTP(w, r)
 		return
 	}
 	h.(http.Handler).ServeHTTP(w, r)
 }
 
+func (m *Mux) SetNotFound(n http.Handler) error {
+	if n == nil {
+		return fmt.Errorf("Not Found handler cannot be nil. Operation rejected.")
+	}
+	m.notFound = n
+	return nil
+}
+
+func (m *Mux) GetNotFound() http.Handler {
+	return m.notFound
+}
+
 // NotFound is a generic http.Handler for request
-type NotFound struct {
+type notFound struct {
 }
 
 // ServeHTTP returns a simple 404 Not found response
-func (NotFound) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (notFound) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/plain")
 	w.WriteHeader(http.StatusNotFound)
 	fmt.Fprint(w, "Not found")


### PR DESCRIPTION
We want to reuse the routing library for other applications, and also
to allow unit testing of vulcan by plugging in mock routing libraries,
or experimental/test routing libraries.

By having NotFound as a public member, it prevents us from plugging in
a replacement interface. By making all implementation private, and exposed
through getters/setters, it allows us to make better effective use of route.

Since vulcan uses godeps to base library versions, I made the potentially
breaking change of renaming NotFound to notFound. This could
potentially break any consumers who rely on it being public, but I think
this chance is for the better. Insofar as vulcan itself is concerned, I'll submit
a change that rebases against this route implementation and uses SetNotFound
methods instead of assigning directly to NotFound.