### PR TITLE
Missed a replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ Features:
 
 Documentation:
 
-http://godoc.org/github.com/mailgun/route
+http://godoc.org/github.com/vulcand/route


### PR DESCRIPTION
This is to update the README.md to point to github.com/vulcand/route 