### PR TITLE
Improve performance when many rules are added to the mux during init

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -20,6 +20,13 @@ func NewMux() *Mux {
 	}
 }
 
+// This adds a map of handlers and expressions in a single call. This allows
+// init to load many rules on first startup, thus reducing the time it takes to
+// create the initial mux.
+func (m *Mux) InitHandlers(handlers map[string]interface{}) error {
+	return m.router.InitRoutes(handlers)
+}
+
 // Handle adds http handler for route expression
 func (m *Mux) Handle(expr string, handler http.Handler) error {
 	return m.router.UpsertRoute(expr, handler)
@@ -71,4 +78,3 @@ func (notFound) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, "Not found")
 
 }
-

--- a/mux_test.go
+++ b/mux_test.go
@@ -38,6 +38,36 @@ func (s *MuxSuite) TestRouting(c *C) {
 	c.Assert(t.buf.String(), Equals, "/p")
 }
 
+func (s *MuxSuite) TestInitHandlers(c *C) {
+	r := NewMux()
+
+	handlers := map[string]interface{} {
+		`Host("localhost") && Path("/p")`: func(w http.ResponseWriter, req *http.Request) {
+			w.WriteHeader(201)
+			w.Write([]byte("/p"))
+		},
+		`Host("localhost") && Path("/f")`: func(w http.ResponseWriter, req *http.Request) {
+			w.WriteHeader(201)
+			w.Write([]byte("/f"))
+		},
+	}
+
+	err := r.InitHandlers(handlers)
+	c.Assert(err, IsNil)
+
+	t := newWriter()
+	r.ServeHTTP(t, makeReq(req{url: "/p", host: "localhost"}))
+
+	c.Assert(t.header, Equals, 201)
+	c.Assert(t.buf.String(), Equals, "/p")
+
+	t = newWriter()
+	r.ServeHTTP(t, makeReq(req{url: "/f", host: "localhost"}))
+
+	c.Assert(t.header, Equals, 201)
+	c.Assert(t.buf.String(), Equals, "/f")
+}
+
 type testWriter struct {
 	header  int
 	buf     *bytes.Buffer

--- a/router.go
+++ b/router.go
@@ -67,6 +67,9 @@ type Router interface {
 	// UpsertRoute updates an existing route or adds a new route by given expression
 	UpsertRoute(string, interface{}) error
 
+	// Initializes the routes, this method clobbers all existing routes and should only be called during init
+	InitRoutes(map[string]interface{}) error
+
 	// Route takes a request and matches it against requests, returns matched route in case if found, nil if there's no matching route or error in case of internal error.
 	Route(*http.Request) (interface{}, error)
 }
@@ -93,6 +96,28 @@ func (e *router) GetRoute(expr string) interface{} {
 	if ok {
 		return res.val
 	}
+	return nil
+}
+
+func (e *router) InitRoutes(routes map[string]interface{}) error {
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+
+	for expr, val := range routes {
+		if _, ok := e.routes[expr]; ok {
+			return fmt.Errorf("expression '%s' already exists", expr)
+		}
+		result := &match{val: val}
+		if _, err := parse(expr, result); err != nil {
+			return err
+		}
+		e.routes[expr] = result
+	}
+
+	if err := e.compile(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -144,7 +169,7 @@ func (e *router) compile() error {
 	}
 	sort.Sort(sort.Reverse(sort.StringSlice(exprs)))
 
-	matchers := []matcher{}
+	var matchers []matcher
 	i := 0
 	for _, expr := range exprs {
 		result := e.routes[expr]


### PR DESCRIPTION
## Purpose
This change allows users to add many routes quickly during mux initialization. Currently, Vulcand takes just under 2 minutes to load 1,600 routes depending on the CPU and load. This change allows Vulcand to load the same number of routes in 200ms.
