### PR TITLE
InitRoutes() now clobbers existing routes

### DIFF
--- a/router.go
+++ b/router.go
@@ -103,10 +103,8 @@ func (e *router) InitRoutes(routes map[string]interface{}) error {
 	e.mutex.Lock()
 	defer e.mutex.Unlock()
 
+	e.routes = make(map[string]*match, len(routes))
 	for expr, val := range routes {
-		if _, ok := e.routes[expr]; ok {
-			return fmt.Errorf("expression '%s' already exists", expr)
-		}
 		result := &match{val: val}
 		if _, err := parse(expr, result); err != nil {
 			return err


### PR DESCRIPTION
## Purpose
Vulcand can get into an infinite loop of failure if a watch error occurs. 

## Implementation
During a watch failure Vulcand attempts to re-init by calling the `init()` method which eventually calls `InitRoutes()`.  However InitRoutes() does not properly clobber previously added routes. This puts vulcand into an infinite loop of failure. This change clobbers existing routes such that calling `InitRoutes()` on a `router` that has already be Initialized does not result in an error.

