### PR TITLE
Added AddAlias() to Mux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ _testmain.go
 *.exe
 *.test
 *.prof
+.idea/

--- a/mux.go
+++ b/mux.go
@@ -3,6 +3,7 @@ package route
 import (
 	"fmt"
 	"net/http"
+	"strings"
 )
 
 // Mux implements router compatible with http.Handler
@@ -10,6 +11,12 @@ type Mux struct {
 	// NotFound sets handler for routes that are not found
 	notFound http.Handler
 	router   Router
+	aliases  []alias
+}
+
+type alias struct {
+	match   string
+	replace string
 }
 
 // NewMux returns new Mux router
@@ -20,24 +27,51 @@ func NewMux() *Mux {
 	}
 }
 
+// AddAlias adds an alias for matchers in an expression. If the string
+// in `match` matches any part of an expression added via `Mux.Handle()`
+// then the match is replaced with the value of `alias`.
+func (m *Mux) AddAlias(match, replace string) {
+	m.aliases = append(m.aliases, alias{match: match, replace: replace})
+}
+
+func (m *Mux) applyAliases(expr string) string {
+	for _, alias := range m.aliases {
+		expr = strings.Replace(expr, alias.match, alias.replace, -1)
+	}
+	return expr
+}
+
 // This adds a map of handlers and expressions in a single call. This allows
 // init to load many rules on first startup, thus reducing the time it takes to
 // create the initial mux.
 func (m *Mux) InitHandlers(handlers map[string]interface{}) error {
-	return m.router.InitRoutes(handlers)
+	if len(m.aliases) == 0 {
+		return m.router.InitRoutes(handlers)
+	}
+
+	// Apply aliases to routes
+	modified := make(map[string]interface{}, len(handlers))
+	for k, v := range handlers {
+		k = m.applyAliases(k)
+		modified[k] = v
+	}
+	return m.router.InitRoutes(modified)
 }
 
 // Handle adds http handler for route expression
 func (m *Mux) Handle(expr string, handler http.Handler) error {
+	expr = m.applyAliases(expr)
 	return m.router.UpsertRoute(expr, handler)
 }
 
 // Handle adds http handler function for route expression
 func (m *Mux) HandleFunc(expr string, handler func(http.ResponseWriter, *http.Request)) error {
+	expr = m.applyAliases(expr)
 	return m.Handle(expr, http.HandlerFunc(handler))
 }
 
 func (m *Mux) Remove(expr string) error {
+	expr = m.applyAliases(expr)
 	return m.router.RemoveRoute(expr)
 }
 

--- a/mux_test.go
+++ b/mux_test.go
@@ -41,15 +41,15 @@ func (s *MuxSuite) TestRouting(c *C) {
 func (s *MuxSuite) TestInitHandlers(c *C) {
 	r := NewMux()
 
-	handlers := map[string]interface{} {
-		`Host("localhost") && Path("/p")`: func(w http.ResponseWriter, req *http.Request) {
+	handlers := map[string]interface{}{
+		`Host("localhost") && Path("/p")`: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			w.WriteHeader(201)
 			w.Write([]byte("/p"))
-		},
-		`Host("localhost") && Path("/f")`: func(w http.ResponseWriter, req *http.Request) {
+		}),
+		`Host("localhost") && Path("/f")`: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			w.WriteHeader(201)
 			w.Write([]byte("/f"))
-		},
+		}),
 	}
 
 	err := r.InitHandlers(handlers)
@@ -66,6 +66,64 @@ func (s *MuxSuite) TestInitHandlers(c *C) {
 
 	c.Assert(t.header, Equals, 201)
 	c.Assert(t.buf.String(), Equals, "/f")
+}
+
+func (s *MuxSuite) TestAddAlias(c *C) {
+	expr := `Host("localhost") && Path("/p")`
+	f := func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(201)
+		w.Write([]byte("/p"))
+	}
+	handler := http.HandlerFunc(f)
+
+	tests := []struct {
+		Init func(r *Mux) error
+	}{
+		{
+			func(r *Mux) error {
+				return r.InitHandlers(map[string]interface{}{expr: handler})
+			},
+		},
+		{
+			func(r *Mux) error {
+				return r.Handle(expr, handler)
+			},
+		},
+		{
+			func(r *Mux) error {
+				return r.HandleFunc(expr, f)
+			},
+		},
+	}
+
+	for _, t := range tests {
+		r := NewMux()
+		r.AddAlias(`Host("localhost")`, `Host("vulcand.net")`)
+
+		err := t.Init(r)
+		c.Assert(err, IsNil)
+
+		// Should not route localhost requests
+		w := newWriter()
+		r.ServeHTTP(w, makeReq(req{url: "/p", host: "localhost"}))
+		c.Assert(w.header, Equals, 404)
+
+		// Should route vulcand.net
+		w = newWriter()
+		r.ServeHTTP(w, makeReq(req{url: "/p", host: "vulcand.net"}))
+		c.Assert(w.header, Equals, 201)
+		c.Assert(w.buf.String(), Equals, "/p")
+
+		// After removing the expression
+		err = r.Remove(expr)
+		c.Assert(err, IsNil)
+
+		// Should NOT route vulcand.net
+		w = newWriter()
+		r.ServeHTTP(w, makeReq(req{url: "/p", host: "vulcand.net"}))
+		c.Assert(w.header, Equals, 404)
+	}
+
 }
 
 type testWriter struct {


### PR DESCRIPTION
## Purpose
This is in support of the `--localhost-alias` for vulcand, previously attempted [here](https://github.com/vulcand/vulcand/pull/350). As requested by @archisgore in this [comment](https://github.com/vulcand/vulcand/pull/350#issuecomment-367798664) . I've added `Mux.AddAlias()` to allow users to add aliases that if matched will transform the expression.

## Implementation
See the unit tests for an example of how this will be used.