### PR TITLE
fix: query string with % and ://

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -19,7 +19,7 @@ func rawPath(r *http.Request) string {
 		path = "/"
 	}
 	// This is absolute URI, split host and port
-	if strings.Contains(path, "://") {
+	if r.URL.Host != "" && strings.Contains(path, "://") {
 		values := strings.SplitN(path, r.URL.Host, 2)
 		if len(values) == 2 {
 			path = values[1]

--- a/utils_test.go
+++ b/utils_test.go
@@ -18,6 +18,7 @@ func Test_rawPath(t *testing.T) {
 		{URL: "/home", Expected: "/home"},
 		{URL: "/home?a=b", Expected: "/home"},
 		{URL: "/home%2F", Expected: "/home%2F"},
+		{URL: "/oauth/callback?scope=email%20https://www.googleapis.com/auth/userinfo.email%20openid", Expected: "/oauth/callback"},
 	}
 	for _, v := range values {
 		out := rawPath(makeReq(req{url: v.URL}))


### PR DESCRIPTION
### The issue

While testing the `vulcan/route` with Google OAuth flow I stumbled upon an issue with the URL to which Google redirects after authentication. Depending on the scopes that you request the shape of it can be like this:

```
/oauth/callback?scope=email%20https://www.googleapis.com/auth/userinfo.email%20openid
```

It contains `%` and `://`. Because of that, it falls into [`values := strings.SplitN(path, r.URL.Host, 2)`](https://github.com/vulcand/route/blob/a879cf12aa896d2f540eaba6001cc1e34344d8da/utils.go#L23). Because the `r.URL.Host` is empty the resulting `path` is `oauth/callback` instead of `/oauth/callback`.

### The solution

Check if the `r.URL.Host` is not empty and only, in that case, perform the `SplitN`